### PR TITLE
update de.flapdoodle.embed.mongo dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <dependency>
             <groupId>de.flapdoodle.embed</groupId>
             <artifactId>de.flapdoodle.embed.mongo</artifactId>
-            <version>1.46.4</version>
+            <version>1.48.2</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
See : https://github.com/flapdoodle-oss/de.flapdoodle.embed.mongo - the current version is 1.48.2. 
